### PR TITLE
fix: Use PATCH for palette update and create stock movement

### DIFF
--- a/modules/Palette/routes.ts
+++ b/modules/Palette/routes.ts
@@ -83,8 +83,8 @@ const updatePaletteByCode = async (id: string): Promise<Palette> => {
         modificationUtilisateur: 'admin'
       };
 
-      // Send the PUT request with the data in the body
-      const { data: updatedPalette } = await axios.put<Palette>(`${baseUrl}/palette/${id}`, updatedData, {
+      // Send the PATCH request with the data in the body
+      const { data: updatedPalette } = await axios.patch<Palette>(`${baseUrl}/palette/${id}`, updatedData, {
         headers: {
           'Content-Type': 'application/json'
         }


### PR DESCRIPTION
This commit resolves a 405 Method Not Allowed error that occurred when updating a palette's status. The HTTP method has been changed from PUT to PATCH, which is the correct method for this API endpoint.

This also includes the full implementation for creating a stock movement automatically after a palette is declared.

- Changed the HTTP method from PUT to PATCH in `updatePaletteByCode`.
- Centralized the stock movement creation logic within the `updatePaletteByCode` function in `modules/Palette/routes.ts`.
- Updated the `Palette` and `Production` interfaces in `types.ts`.
- Removed redundant logic from the `screens/Palette.tsx` component.